### PR TITLE
Fix touch

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -259,6 +259,10 @@ function mousePressed() {
   testPizza2.pressed(mouseX, mouseY);
 }
 
+// just having this callback fixed touch
+function touchStarted() {
+}
+
 function changeKit(kit, pizza) {
   let choice = kit.value();
   switch(choice){

--- a/sketch.js
+++ b/sketch.js
@@ -259,7 +259,8 @@ function mousePressed() {
   testPizza2.pressed(mouseX, mouseY);
 }
 
-// just having this callback fixed touch
+// mousePressed will be coalled when no touch start is defined which is not what we want
+// https://p5js.org/reference/#/p5/touchStarted
 function touchStarted() {
 }
 


### PR DESCRIPTION
When using with a touch display this small this allow to create notes. Before this was broken as touch had mouse pressed as a fallback which started a selection process,